### PR TITLE
Add dedicated header for syscall hooking

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -14,6 +14,7 @@
 #include "env.h"
 #include "internal.h"
 #include "logger.h"
+#include "syscall_hook.h"
 #include "util/cirbuf.h"
 #include "util/shm.h"
 #include "util/spinlock.h"
@@ -66,7 +67,7 @@ static enum LOG_LEVEL log_str_level(const char *level)
 }
 
 /* FIXME: move the prototype to dedicated header */
-extern ssize_t (*real_sys_write)(int fd, const void *buf, size_t count);
+//extern ssize_t (*real_sys_write)(int fd, const void *buf, size_t count);
 
 static void log_flush()
 {

--- a/src/syscall_hook.c
+++ b/src/syscall_hook.c
@@ -10,8 +10,21 @@ sys_accept real_sys_accept = NULL;
 sys_read real_sys_read = NULL;
 sys_recv real_sys_recv = NULL;
 
+<<<<<<< HEAD
 sys_write real_sys_write = NULL;
 sys_send real_sys_send = NULL;
+=======
+static sys_connect real_sys_connect = NULL;
+static sys_accept real_sys_accept = NULL;
+
+static sys_read real_sys_read = NULL;
+static sys_recv real_sys_recv = NULL;
+
+sys_write real_sys_write = NULL;
+static sys_send real_sys_send = NULL;
+
+#define fd_not_ready() ((EAGAIN == errno) || (EWOULDBLOCK == errno))
+>>>>>>> 88603ac... Remove meaningless comment
 
 static void event_rw_callback(void *args)
 {

--- a/src/syscall_hook.h
+++ b/src/syscall_hook.h
@@ -1,0 +1,57 @@
+#ifndef CORE_SYSCALL_HOOK_H
+#define CORE_SYSCALL_HOOK_H
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+typedef int (*sys_connect)(int sockfd,
+                           const struct sockaddr *addr,
+                           socklen_t addrlen);
+typedef int (*sys_accept)(int sockfd,
+                          struct sockaddr *addr,
+                          socklen_t *addrlen);
+
+typedef ssize_t (*sys_read)(int fd, void *buf, size_t count);
+typedef ssize_t (*sys_recv)(int sockfd, void *buf, size_t len, int flags);
+
+typedef ssize_t (*sys_write)(int fd, const void *buf, size_t count);
+typedef ssize_t (*sys_send)(int sockfd, const void *buf, size_t len, int flags);
+
+#define HOOK_SYSCALL(name) \
+    real_sys_##name = (sys_##name) dlsym(RTLD_NEXT, #name)
+
+#define CONN_TIMEOUT (10 * 1000)
+#define ACCEPT_TIMEOUT (3 * 1000)
+
+#define READ_TIMEOUT (10 * 1000)
+#define RECV_TIMEOUT (10 * 1000)
+
+#define WRITE_TIMEOUT (10 * 1000)
+#define SEND_TIMEOUT (10 * 1000)
+
+#define KEEP_ALIVE 60
+
+extern sys_connect real_sys_connect;
+extern sys_accept real_sys_accept;
+
+extern sys_read real_sys_read;
+extern sys_recv real_sys_recv;
+
+extern sys_write real_sys_write;
+extern sys_send real_sys_send;
+
+#define fd_not_ready() ((EAGAIN == errno) || (EWOULDBLOCK == errno))
+
+/* hooked system calls */
+int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+ssize_t read(int fd, void *buf, size_t count);
+ssize_t recv(int sockfd, void *buf, size_t len, int flags);
+ssize_t write(int fd, const void *buf, size_t count);
+ssize_t send(int sockfd, const void *buf, size_t len, int flags);
+
+#endif


### PR DESCRIPTION
Fix the redundant usage like "extern ssize_t (*real_sys_write)(...);".
After including "syscall_hook.h", then usage of any real_sys_{}
functions will be available.
Main purpose of new header, a.k.a. "syscall_hook.h" is to globalize
all real_sys_{} functions and give syscall_hook a dedicated header.