### PR TITLE
Add dedicated header for syscall hooking

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -11,6 +11,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "syscall_hook.h"
 #include "env.h"
 #include "internal.h"
 #include "logger.h"
@@ -64,9 +65,6 @@ static enum LOG_LEVEL log_str_level(const char *level)
     printf("unknow log level. %s\n", level);
     exit(0);
 }
-
-/* FIXME: move the prototype to dedicated header */
-extern ssize_t (*real_sys_write)(int fd, const void *buf, size_t count);
 
 static void log_flush()
 {

--- a/src/syscall_hook.c
+++ b/src/syscall_hook.c
@@ -5,23 +5,11 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#include "syscall_hook.h"
 #include "coro/sched.h"
 #include "event.h"
 #include "internal.h"
 #include "util/net.h"
-
-typedef int (*sys_connect)(int sockfd,
-                           const struct sockaddr *addr,
-                           socklen_t addrlen);
-typedef int (*sys_accept)(int sockfd,
-                          struct sockaddr *addr,
-                          socklen_t *addrlen);
-
-typedef ssize_t (*sys_read)(int fd, void *buf, size_t count);
-typedef ssize_t (*sys_recv)(int sockfd, void *buf, size_t len, int flags);
-
-typedef ssize_t (*sys_write)(int fd, const void *buf, size_t count);
-typedef ssize_t (*sys_send)(int sockfd, const void *buf, size_t len, int flags);
 
 #define HOOK_SYSCALL(name) \
     real_sys_##name = (sys_##name) dlsym(RTLD_NEXT, #name)
@@ -43,7 +31,7 @@ static sys_accept real_sys_accept = NULL;
 static sys_read real_sys_read = NULL;
 static sys_recv real_sys_recv = NULL;
 
-sys_write real_sys_write = NULL; /* shared with log.c */
+sys_write real_sys_write = NULL;
 static sys_send real_sys_send = NULL;
 
 #define fd_not_ready() ((EAGAIN == errno) || (EWOULDBLOCK == errno))

--- a/src/syscall_hook.h
+++ b/src/syscall_hook.h
@@ -1,0 +1,22 @@
+#ifndef CORE_SYSCALL_HOOK_H
+#define CORE_SYSCALL_HOOK_H
+
+#include <sys/socket.h>
+
+typedef int (*sys_connect)(int sockfd,
+                           const struct sockaddr *addr,
+                           socklen_t addrlen);
+typedef int (*sys_accept)(int sockfd,
+                          struct sockaddr *addr,
+                          socklen_t *addrlen);
+
+typedef ssize_t (*sys_read)(int fd, void *buf, size_t count);
+typedef ssize_t (*sys_recv)(int sockfd, void *buf, size_t len, int flags);
+
+typedef ssize_t (*sys_write)(int fd, const void *buf, size_t count);
+typedef ssize_t (*sys_send)(int sockfd, const void *buf, size_t len, int flags);
+
+/* declared in syscall_hook.c */
+extern sys_write real_sys_write;
+
+#endif


### PR DESCRIPTION
Fix redundent code: "extern ssize_t (*real_sys_write)(...);" in "logger.c"
by adding a header called "syscall_hook.h" for globalizing "real_sys_write"