### PR TITLE
Resolve incomplete coroutine initialization

### DIFF
--- a/src/coro/sched.c
+++ b/src/coro/sched.c
@@ -154,6 +154,9 @@ static void move_to_inactive_tree(struct coroutine *coro)
     struct timer_node *tmp = memcache_alloc(sched.cache);
     if (unlikely(!tmp)) /* still in active list */
         return;
+    tmp->root = RB_ROOT;
+    tmp->node.rb_left = NULL;
+    tmp->node.rb_right = NULL;
 
     tmp->timeout = coro->timeout;
     add_to_timer_node(tmp, coro);


### PR DESCRIPTION
This commit fixes the problem of a segmentation fault that occurs after enabling AddressSanitizer.
Uninitialized variables will now be marked by ASan, and if accessed, they will cause a SEGV (Segmentation Violation) error (see #6).