### PR TITLE
Ignore 'fallthrough' warning

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -27,5 +27,11 @@
 #define ATTRIBUTE_REGPARM(n)
 #endif
 
+#if __has_attribute(__fallthrough__)
+#define fallthrough __attribute__((__fallthrough__))
+#else
+#define fallthrough do {} while (0)  /* fallthrough */
+#endif
+
 /* Misc */
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))

--- a/src/http/parse.c
+++ b/src/http/parse.c
@@ -212,12 +212,14 @@ int http_parse_request_line(struct http_request *r, struct buffer *b)
                 break;
             }
             state = S_host;
+            fallthrough;
         case S_host:
             c = (unsigned char) (ch | 0x20);
             if (c >= 'a' && c <= 'z')
                 break;
             if ((ch >= '0' && ch <= '9') || ch == '.' || ch == '-')
                 break;
+            fallthrough;
         case S_host_end:
             r->host.len = p - r->host.p;
             switch (ch) {


### PR DESCRIPTION
Test on virtualBox ubuntu server
```
$ lscpu | head -n 6
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Address sizes:                   39 bits physical, 48 bits virtual
Byte Order:                      Little Endian
CPU(s):                          4
On-line CPU(s) list:             0-3
```
Tested on Raspberry Pi 4B:
```
$ lscpu | head -n 6
Architecture:                    aarch64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
CPU(s):                          4
On-line CPU(s) list:             0-3
Vendor ID:                       ARM
```